### PR TITLE
一个小地方，会导致我的mysql添加条目FAIL.

### DIFF
--- a/controllers/admin/article.go
+++ b/controllers/admin/article.go
@@ -138,6 +138,7 @@ func (this *ArticleController) Save() {
 		post.Userid = this.userid
 		post.Author = this.username
 		post.Posttime = this.getTime()
+		post.Updated = post.getTime()
 		post.Insert()
 	} else {
 		post.Id = id


### PR DESCRIPTION
不给post.Updated初始化会在新建article时失败，我用的是mysql..有如下提示:

[ORM] - 2014-07-12 01:13:02 - [Queries/default] - [FAIL /     db.Exec /     1.8ms] - [INSERT INTO `tb_post` (`userid`, `author`, `title`, `color`, `urlname`, `urltype`, `content`, `tags`, `posttime`, `views`, `status`, `updated`, `istop`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)] - `1`, `admin`, ``, ``, ``, `0`, ``, ``, `2014-07-12 09:13:02.637376317 +0800 +0800`, `0`, `0`, `<nil>`, `0` - Error 1048: Column 'updated' cannot be null